### PR TITLE
Avoid error when there is no changes to commit

### DIFF
--- a/app/scripts/common.sh
+++ b/app/scripts/common.sh
@@ -99,7 +99,7 @@ function gitCommandIsThereFilesToCommit {
   PRJ=$1
   shift
   shift
-  if [ -z $(cd $PRJ_DIR/$PRJ && git status --porcelain  2>&1) ];
+  if [ -z "$(cd $PRJ_DIR/$PRJ && git status --porcelain  2>&1)" ];
   then
       echo "false"
   else


### PR DESCRIPTION
fix to avoid this log : 
`/opt/exo-release/scripts/common.sh: line 102: [: M: binary operator expected`
