### PR TITLE
Improve release staging repository phase for CI/CD

### DIFF
--- a/app/scripts/process/nexus-repos.sh
+++ b/app/scripts/process/nexus-repos.sh
@@ -111,8 +111,11 @@ function nexus_close_staging_repo {
    maven_server_id=$NEXUS_JBOSS_STAGING_SERVER_ID
   fi
   ######################  NEXUS JBOSS TESTS #####################
-
-  mvnCommand $1 nexus-staging:rc-close -DserverId=$maven_server_id -DnexusUrl=$nexus_url -DstagingRepositoryId=$2 -DstagingDescription=$5 -DautoReleaseAfterClose=${6:-false} 2>&1 | tee -a ${LOGS_DIR}/infos.log
+  if [ ${6:-false} = "true" ]; then
+    mvnCommand $1 nexus-staging:rc-close nexus-staging:rc-release -DserverId=$maven_server_id -DnexusUrl=$nexus_url -DstagingRepositoryId=$2 -DstagingDescription=$5 2>&1 | tee -a ${LOGS_DIR}/infos.log
+  else
+    mvnCommand $1 nexus-staging:rc-close -DserverId=$maven_server_id -DnexusUrl=$nexus_url -DstagingRepositoryId=$2 -DstagingDescription=$5 2>&1 | tee -a ${LOGS_DIR}/infos.log
+  fi
   printFooter "Close Nexus Repository (Repo ID: $2)"
   # log status
   release_status_write_step $NEXUS_CLOSE_STAGING_REPO $STATUS_DONE


### PR DESCRIPTION
The maven flag autoReleaseAfterClose is not working when closing the staging repository. In addition it is risky to perform asynchronous action (release).
In this change, this PR makes sure that the release phase is performed before creating Github Tags