### PR TITLE
Remove unnecessary method call to skip snapshot fetch during release workflow

### DIFF
--- a/app/scripts/eXoR.sh
+++ b/app/scripts/eXoR.sh
@@ -163,7 +163,15 @@ function exor_release_project {
       # Notification to Tribe Task
       task_add_comment $projectName "release_perform_OK" $issueId
 
-      maven_dependencies_update_after_release $projectName $issueId
+      # Fix: Workaround to allow project release without resolving SNAPSHOT dependencies
+      # during the staging repository's close and release process.
+      #
+      # Note: This step is unnecessary because the workflow doesn't push changes with
+      # the next_snapshot_version to the release branch. It only creates a local
+      # release/$releaseVersion branch without modifying the remote.
+      # If push needed, this should be called after the release process, and complete the missing push part.
+      #
+      # maven_dependencies_update_after_release $projectName $issueId
 
       # Create Nexus Staging Repositry
       description="$issueId:$projectName:$tagName"


### PR DESCRIPTION
This PR removes the unnecessary call to maven_dependencies_update_after_release, which caused Maven to fetch SNAPSHOT dependencies during the release process.

Originally, this method was intended to update the snapshot version after a project release. However, the corresponding step to push the release branch was never implemented. Furthermore, the snapshot version update triggered Maven to fetch SNAPSHOT dependencies, which was not required. Removing this method eliminates the unnecessary dependency fetch, streamlining the release process and avoiding potential issues.