### PR TITLE
fix: improve getProjectByNameFromCatalog and correct exception handling

### DIFF
--- a/app/scripts/eXoR.sh
+++ b/app/scripts/eXoR.sh
@@ -220,9 +220,9 @@ function exor_release_project {
         ;;
         *)
             error "[$ex_code] An unexpected exception was thrown"
-            throw $ex_code # you can rethrow the "exception" causing the script to exit if not caught
         ;;
     esac
+    throw $ex_code # you can rethrow the "exception" causing the script to exit if not caught
   }
 }
 
@@ -403,9 +403,9 @@ function exor_release_from_step {
           ;;
           *)
               error "[$ex_code] An unexpected exception was thrown"
-              throw $ex_code # you can rethrow the "exception" causing the script to exit if not caught
           ;;
       esac
+      throw $ex_code # you can rethrow the "exception" causing the script to exit if not caught
   }
 }
 


### PR DESCRIPTION
- Simplified logic by removing unnecessary loop and array usage
- Improved safety by using proper quoting and `jq` argument handling
- Moved exception handling to appropriate location to prevent incorrect behavior